### PR TITLE
Add minimal Next.js MVP skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_openai_key_here

--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# memoria-antonio-mvp
+# Memoria Antonio MVP
+
+This repository contains a minimal prototype of **Memoria**, an AI-powered personal operating system built with Next.js and TypeScript.
+
+## Setup
+
+1. Install dependencies with `npm install`.
+2. Copy `.env.example` to `.env.local` and add your `OPENAI_API_KEY`.
+3. Run the development server with `npm run dev`.
+
+## Features
+
+- Simple feed showing Antonio's memories
+- Chat interface powered by OpenAI
+- Placeholder pages for calendar, shop, and settings
+
+This MVP is only a starting point for the full vision described in the project documentation.

--- a/components/Feed.tsx
+++ b/components/Feed.tsx
@@ -1,0 +1,15 @@
+import InsightBlock from './InsightBlock'
+import PromptCard from './PromptCard'
+import data from '../data/antonio.json'
+
+export default function Feed() {
+  const memories = data.memories || []
+  return (
+    <div className="space-y-4">
+      {memories.map((mem, idx) => (
+        <InsightBlock key={idx} memory={mem} />
+      ))}
+      <PromptCard />
+    </div>
+  )
+}

--- a/components/InsightBlock.tsx
+++ b/components/InsightBlock.tsx
@@ -1,0 +1,12 @@
+interface Props {
+  memory: { date: string; text: string }
+}
+
+export default function InsightBlock({ memory }: Props) {
+  return (
+    <div className="p-4 border rounded">
+      <p className="text-xs text-gray-500">{memory.date}</p>
+      <p>{memory.text}</p>
+    </div>
+  )
+}

--- a/components/PromptCard.tsx
+++ b/components/PromptCard.tsx
@@ -1,0 +1,7 @@
+export default function PromptCard() {
+  return (
+    <div className="p-4 bg-blue-100 rounded">
+      <p className="text-sm">How are you feeling today? Remember to check in with yourself.</p>
+    </div>
+  )
+}

--- a/data/antonio.json
+++ b/data/antonio.json
@@ -1,0 +1,7 @@
+{
+  "memories": [
+    {"date": "2023-08-01", "text": "Walked to class, felt energized."},
+    {"date": "2023-08-02", "text": "Took the metro, mood decreased."},
+    {"date": "2023-08-03", "text": "Skipped breakfast and felt tired."}
+  ]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts']
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "memoria-antonio-mvp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "jest"
+  },
+  "dependencies": {
+    "next": "13.4.10",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "openai": "^3.2.1"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.3",
+    "typescript": "^5.0.4",
+    "@types/node": "^20.2.5",
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "eslint": "8.40.0",
+    "eslint-config-next": "13.4.10",
+    "jest": "^29.5.0",
+    "@testing-library/react": "^13.4.0",
+    "@testing-library/jest-dom": "^5.16.5",
+    "node-mocks-http": "^1.11.0"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,6 @@
+import '../styles/globals.css'
+import type { AppProps } from 'next/app'
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}

--- a/pages/api/chatgpt.ts
+++ b/pages/api/chatgpt.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { Configuration, OpenAIApi } from 'openai'
+import data from '../../data/antonio.json'
+
+const openai = new OpenAIApi(new Configuration({ apiKey: process.env.OPENAI_API_KEY }))
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' })
+    return
+  }
+  try {
+    const { message } = req.body
+    const context = data.memories.map((m: any) => m.text).join('\n')
+    const completion = await openai.createChatCompletion({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: `Context:\n${context}` },
+        { role: 'user', content: message }
+      ]
+    })
+    const reply = completion.data.choices[0]?.message?.content || ''
+    res.status(200).json({ response: reply })
+  } catch (err) {
+    console.error(err)
+    res.status(500).json({ error: 'Failed to fetch from OpenAI' })
+  }
+}

--- a/pages/calendar.tsx
+++ b/pages/calendar.tsx
@@ -1,0 +1,8 @@
+export default function Calendar() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Calendar</h1>
+      <p>Calendar view coming soon.</p>
+    </div>
+  )
+}

--- a/pages/chat.tsx
+++ b/pages/chat.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react'
+
+export default function Chat() {
+  const [messages, setMessages] = useState<string[]>([])
+  const [input, setInput] = useState('')
+
+  async function sendMessage() {
+    if (!input) return
+    setMessages([...messages, input])
+    const res = await fetch('/api/chatgpt', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: input })
+    })
+    const data = await res.json()
+    setMessages(msgs => [...msgs, data.response])
+    setInput('')
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Chat</h1>
+      <div className="space-y-2">
+        {messages.map((msg, idx) => (
+          <div key={idx} className="p-2 bg-gray-100 rounded">{msg}</div>
+        ))}
+      </div>
+      <div className="flex space-x-2 mt-4">
+        <input
+          className="flex-1 border p-2 rounded"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          placeholder="Say something..."
+        />
+        <button onClick={sendMessage} className="bg-blue-500 text-white px-4 rounded">
+          Send
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,10 @@
+import Feed from '../components/Feed'
+
+export default function Home() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Memoria</h1>
+      <Feed />
+    </div>
+  )
+}

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -1,0 +1,8 @@
+export default function Settings() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Settings</h1>
+      <p>Toggle your privacy and data preferences here.</p>
+    </div>
+  )
+}

--- a/pages/shop.tsx
+++ b/pages/shop.tsx
@@ -1,0 +1,8 @@
+export default function Shop() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Shop</h1>
+      <p>Recommended products will appear when relevant.</p>
+    </div>
+  )
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,0 +1,10 @@
+import handler from '../pages/api/chatgpt'
+import { createMocks } from 'node-mocks-http'
+
+describe('POST /api/chatgpt', () => {
+  it('returns 405 on GET', async () => {
+    const { req, res } = createMocks({ method: 'GET' })
+    await handler(req as any, res as any)
+    expect(res._getStatusCode()).toBe(405)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add Next.js project structure with TypeScript and Tailwind
- implement basic pages (`index`, `chat`, `calendar`, `shop`, `settings`)
- implement simple components (`Feed`, `PromptCard`, `InsightBlock`)
- add OpenAI chat API route using Antonio's memory data
- add sample data, config files, and placeholder tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489e85860483308f4d82452e3e7c69